### PR TITLE
Fix errors in compute shaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ The project can be compiled on both Linux using CMake and the respective build s
   ```
     VK_LAYER_PATH=/usr/local/x86_64/etc/explicit_layer.d/ bin/testvulkan
   ```
+
+# Running on a descrete nvidia gpu with nvidia-prime
+
+I use wayland and integrated intel GPU on my ubuntu laptop. To make nvidia GPU compute something in such a setting, I need to do couple extra steps in bash *before* running the service:
+```bash
+sudo modprobe nvidia
+export LD_LIBRARY_PATH=/usr/lib/nvidia-384:$LD_LIBRARY_PATH
+unset DISPLAY
+unset unset XDG_SESSION_TYPE
+```
+The commands above set up an environment to run vulkan using an nvidia GPU headless (without a display environment). 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ I use wayland and integrated intel GPU on my ubuntu laptop. To make nvidia GPU c
 sudo modprobe nvidia
 export LD_LIBRARY_PATH=/usr/lib/nvidia-384:$LD_LIBRARY_PATH
 unset DISPLAY
-unset unset XDG_SESSION_TYPE
+unset XDG_SESSION_TYPE
 ```
 The commands above set up an environment to run vulkan using an nvidia GPU headless (without a display environment). 

--- a/include/quavis/quavis.h
+++ b/include/quavis/quavis.h
@@ -217,8 +217,8 @@ namespace quavis {
     std::vector<uint32_t> indices_ = {};
     UniformBufferObject uniform_ = {
       vec3 {0, 0, 0},
-      1000000,
-      .1
+      10000,
+      .3
     };
 
     // debug attributes

--- a/src/context.cc
+++ b/src/context.cc
@@ -220,7 +220,9 @@ void Context::InitializeVkPhysicalDevice() {
   );
   if (num_devices == 0)
     throw "No suitible device.";
-
+  
+  
+  std::cout << "Number of devices: " << num_devices << std::endl;
   // get the devices
   std::vector<VkPhysicalDevice> devices(num_devices);
   vkEnumeratePhysicalDevices(
@@ -346,12 +348,25 @@ void Context::InitializeVkPhysicalDevice() {
     device_it++;
   }
 
-  // Check if there are devices meeting the requirements
-  // if so, pick the first one (random)
+  // prefer discrete GPU.
+  // other than that, use any card meeting the requirements
+  VkPhysicalDevice dev;
+  VkPhysicalDeviceProperties props;
+  for (device_it = devices_set.begin(); device_it != devices_set.end();) {
+    vkGetPhysicalDeviceProperties(*device_it, &props);
+    if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+      dev = *device_it;
+      break;
+    }
+    device_it++;
+  }
+  std::cout << "Number of GPUs fit: " << devices_set.size() << std::endl;
   if (devices_set.size() == 0)
     throw "No suitible device";
-  else
-    this->vk_physical_device_ = *devices_set.begin();
+  else {
+    std::cout << "Selected: " << props.deviceName << std::endl;
+    this->vk_physical_device_ = dev;
+  }
 }
 
 void Context::InitializeVkLogicalDevice() {

--- a/src/shaders/shader.area.comp
+++ b/src/shaders/shader.area.comp
@@ -25,13 +25,11 @@ void main()
 
   // compute sum per item
   uint ypos = gl_LocalInvocationID.x * chunksize;
-  float tmp = 0.0;
+  float tmp = 1.0;
   for (uint y = ypos; y < ypos + chunksize; y++) {
     if (ypos < HEIGHT/2) {
         float loaded = imageLoad(inputImage, ivec2(gl_WorkGroupID.x, y)).x;
-        tmp = tmp == 0 ? loaded
-                       : loaded == 0 ? tmp
-                                     : min(tmp, loaded);
+        tmp = loaded <= 0 ? tmp : min(tmp, loaded);
     }
   }
   tmp_local[gl_LocalInvocationID.x] = tmp;

--- a/src/shaders/shader.maxradial.comp
+++ b/src/shaders/shader.maxradial.comp
@@ -25,13 +25,11 @@ void main()
 
   // compute sum per item
   uint ypos = gl_LocalInvocationID.x * chunksize;
-  float tmp = 0.0;
+  float tmp = 1.0;
   for (uint y = ypos; y < ypos + chunksize; y++) {
     //compute per chunk
     float loaded = imageLoad(inputImage, ivec2(gl_WorkGroupID.x, y)).x;
-    tmp = tmp == 0 ? loaded
-                   : loaded == 0 ? tmp
-                                 : min(tmp, loaded);
+    tmp = loaded <= 0 ? tmp : min(tmp, loaded);
   }
   tmp_local[gl_LocalInvocationID.x] = tmp;
   barrier();

--- a/src/shaders/shader.skyratio.comp
+++ b/src/shaders/shader.skyratio.comp
@@ -6,7 +6,6 @@
 // constants
 #define N_LOCAL 16
 #define PI 3.1415926
-#define R_MAX 0.0001
 
 layout (local_size_x = N_LOCAL, local_size_y = 1, local_size_z = 1) in;
 
@@ -26,20 +25,22 @@ void main()
 
   // compute sum per item
   uint ypos = gl_LocalInvocationID.x * chunksize;
+  float piH = PI/float(HEIGHT);
   float tmp = 0.0;
-  for (uint y = ypos; y < ypos + chunksize; y++) {
-     {
-      float loaded = imageLoad(inputImage, ivec2(gl_WorkGroupID.x, y)).x;
-      if (loaded == 0.0) tmp += sin((y + 0.5f)*PI/float(HEIGHT)*PI/2/float(HEIGHT)/float(HEIGHT));
+  for (uint y = ypos; y < ypos + chunksize && y*2 < HEIGHT; y++) {
+    {
+      // we rely on the fragment shader saving non-zero value to all components of output image.
+      float r = imageLoad(inputImage, ivec2(gl_WorkGroupID.x, y)).y;
+      if (r == 0.0) tmp += sin((y + 0.5f)*piH);
     }
   }
-  tmp_local[gl_LocalInvocationID.x] = tmp;
+  tmp_local[gl_LocalInvocationID.x] = tmp * PI/2/float(HEIGHT)/float(HEIGHT);
   barrier();
 
   // group sum
   for (uint stride = N_LOCAL >> 1; stride > 0; stride >>= 1) {
     if (gl_LocalInvocationID.x < stride) {
-      tmp_local[gl_LocalInvocationID.x] += tmp_local[gl_LocalInvocationID.x];
+      tmp_local[gl_LocalInvocationID.x] += tmp_local[gl_LocalInvocationID.x + stride];
     }
     barrier();
   }

--- a/src/shaders/shader.volume.comp
+++ b/src/shaders/shader.volume.comp
@@ -28,6 +28,7 @@ void main()
   float tmp = 0.0;
   for (uint y = ypos; y < ypos + chunksize; y++) {
     float r = imageLoad(inputImage, ivec2(gl_WorkGroupID.x, y)).x;
+    if (r == 0.0) r = 1.0;
     tmp += r * r * r * sin((y+0.5)*PI/float(HEIGHT));
   }
   tmp_local[gl_LocalInvocationID.x] = tmp;


### PR DESCRIPTION
The main problem is that output image clear color is set to 0 0 0 1, whereas default depth should be 1. As a result, distances were not calculated correctly.